### PR TITLE
phusion//baseimage-docker refactor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ###########################################################
 # base image, used for build stages and final images
-FROM ubuntu:20.04 as base
+FROM phusion/baseimage:focal-1.2.0 as base
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN mkdir /opt/arm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
 ###########################################################
 # base image, used for build stages and final images
 FROM phusion/baseimage:focal-1.2.0 as base
-ENV DEBIAN_FRONTEND=noninteractive
 
 RUN mkdir /opt/arm
 WORKDIR /opt/arm
-
-COPY ./scripts/add-ppa.sh /root/add-ppa.sh
 
 # start by updating and upgrading the OS
 RUN \
@@ -29,6 +26,7 @@ RUN install_clean \
         vim
 
 # add the PPAs we need, using add-ppa.sh since add-apt-repository is unavailable
+COPY ./scripts/add-ppa.sh /root/add-ppa.sh
 RUN \
     bash /root/add-ppa.sh ppa:mc3man/focal6 && \
     bash /root/add-ppa.sh ppa:heyarje/makemkv-beta && \
@@ -74,18 +72,12 @@ FROM deps-ripper as arm-dependencies
 
 # install makemkv and handbrake
 RUN install_clean \
-        rsyslog \
         handbrake-cli \
         makemkv-bin \
         makemkv-oss
 
 # clean up apt
 RUN apt clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-RUN sed -i '/imklog/s/^/#/' /etc/rsyslog.conf
-
-# reset to default after build
-ENV DEBIAN_FRONTEND=newt
 
 # set metadata
 LABEL org.opencontainers.image.source=https://github.com/shitwolfymakes/arm-dependencies

--- a/README.md
+++ b/README.md
@@ -39,8 +39,3 @@ To base your docker container on `arm-dependencies`, add this to the top of your
 ```dockerfile
 FROM shitwolfymakes/arm-dependencies AS base
 ```
-
-To start the rsyslog service included in this container, add the following command before the command to run `armui.py` in your `Dockerfile`:
-```dockerfile
-CMD service rsyslog start
-```


### PR DESCRIPTION
This PR updates arm-dependencies to build on top of https://github.com/phusion/baseimage-docker to make life easier and allow access to new features. ARM properly builds and runs off of this docker image